### PR TITLE
Call `removeQuery` instead of `stopQuery`

### DIFF
--- a/.changeset/heavy-seals-notice.md
+++ b/.changeset/heavy-seals-notice.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client-react-streaming": patch
+---
+
+Call `removeQuery` instead of `stopQuery` to be more compatible with Apollo Client 4.0.

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
@@ -148,7 +148,7 @@ class ApolloClientClientBaseImpl extends ApolloClientBase {
           })
         ),
       })
-      .finally(() => queryManager.stopQuery(queryId));
+      .finally(() => queryManager.removeQuery(queryId));
 
     this.simulatedStreamingQueries.set(id, {
       controller,
@@ -223,7 +223,7 @@ class ApolloClientClientBaseImpl extends ApolloClientBase {
           })
         ),
       })
-      .finally(() => queryManager.stopQuery(queryId));
+      .finally(() => queryManager.removeQuery(queryId));
   };
 }
 


### PR DESCRIPTION
This pairs with https://github.com/apollographql/apollo-client/pull/12566