### PR TITLE
change preloadQuery tanstack to transport query preload function

### DIFF
--- a/.changeset/calm-snakes-mate.md
+++ b/.changeset/calm-snakes-mate.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client-integration-tanstack-start": patch
+---
+
+change `preloadQuery` type to `PreloadTransportedQueryFunction`

--- a/packages/tanstack-start/src/routerWithApolloClient.tsx
+++ b/packages/tanstack-start/src/routerWithApolloClient.tsx
@@ -1,21 +1,19 @@
 import {
   isTransportedQueryRef,
   reviveTransportedQueryRef,
+  type PreloadTransportedQueryFunction,
 } from "@apollo/client-react-streaming";
 import type { ApolloClient } from "@apollo/client-react-streaming";
 import { createTransportedQueryPreloader } from "@apollo/client-react-streaming";
 import { ApolloProvider } from "./ApolloProvider.js";
-import {
-  createQueryPreloader,
-  type PreloadQueryFunction,
-} from "@apollo/client/react/index.js";
+import { createQueryPreloader } from "@apollo/client/react/index.js";
 import { type AnyRouter } from "@tanstack/react-router";
 import React from "react";
 
 /** @alpha */
 export interface ApolloClientRouterContext {
   apolloClient: ApolloClient;
-  preloadQuery: PreloadQueryFunction;
+  preloadQuery: PreloadTransportedQueryFunction;
 }
 
 /** @alpha */
@@ -29,10 +27,10 @@ export function routerWithApolloClient<TRouter extends AnyRouter>(
 
   context.apolloClient = apolloClient;
   context.preloadQuery = router.isServer
-    ? (createTransportedQueryPreloader(
+    ? createTransportedQueryPreloader(apolloClient)
+    : (createQueryPreloader(
         apolloClient
-      ) as unknown as PreloadQueryFunction)
-    : createQueryPreloader(apolloClient);
+      ) as unknown as PreloadTransportedQueryFunction);
 
   const originalHydrate = router.options.hydrate;
   router.options.hydrate = (...args) => {


### PR DESCRIPTION
With the typing of `context.preloadQuery` in the tanstack start intergration, It's possible to write code like this in a loader:

```ts
 const _movieQueryRef = preloadQuery(GET_MOVIES_SEARCH, {
   variables: {
     search: query,
     page,
   },
 });

const movieQueryRef = await _movieQueryRef.toPromise();

return { movieQueryRef };
```

(This is similar to how `ensureQueryData` would be used in an Tanstack Start and Query application)

However, because in start loaders are isomorphic, in server mode the `moveQueryRef` is typed as a `PreloadedQueryRef` when it's actually a `PreloadedQueryRef` on the browser and a `TransportedQueryRef` on the server. `toPromise` does not exist right now on `TransportedQueryRef` so you get a null error that was not caught by the Blessed Squiggly Line in Code/Cursor/Typescript LSP.

Solution in this PR is just to reverse it to always being  `TransportedQueryRef` always since it seems to be a mostly strict subset of `PreloadedQueryRef`. 